### PR TITLE
Add `tests` keyword argument to `go` function

### DIFF
--- a/src/run.jl
+++ b/src/run.jl
@@ -64,7 +64,7 @@ function test(dir, tmp, idx; dead = false)
   return !pass
 end
 
-function go(dir, ps = defaults; procs = 1, dead = false)
+function go(dir, ps = defaults; procs = 1, dead = false, tests = typemax(Int))
   runs, pass = 0, 0
   function run(r, i)
     runs += 1
@@ -77,7 +77,7 @@ function go(dir, ps = defaults; procs = 1, dead = false)
   rm(tmp, recursive=true)
   @sync for i = 1:procs
     let tmp = initialise(dir), idx = indices(joinpath(tmp, "src"), ps)
-      @async while true
+      @async while runs < tests
         run(test(dir, tmp, idx, dead = dead), i)
       end
     end


### PR DESCRIPTION
Currently, the `Vimes.go` function will run indefinitely until the user manually interrupts it with `Ctrl-C`.

This pull request adds a `tests` keyword argument to the `go` function. When the user provides a finite value for `tests`, `go` will stop running after `tests` runs.

The default value for `tests` is `typemax(Int)`. Therefore, if the user does not specify a value for `tests`, then the `go` function will run for a very long time.

cc: @MikeInnes
