### PR TITLE
Include all files and folders in the source directory

### DIFF
--- a/src/run.jl
+++ b/src/run.jl
@@ -14,9 +14,10 @@ function initialise(dir)
     error("No Julia project found at $dir")
   tmp = joinpath(tempdir(), "vimes-$(rand(UInt64))")
   mkdir(tmp)
-  for path in ["Project.toml", "Manifest.toml", "src", "test", "deps"]
-    ispath(joinpath(dir, path)) &&
-      cp(joinpath(dir, path), joinpath(tmp, path))
+  for path in readdir(dir)
+      if !startswith(path, “.”)
+          cp(joinpath(dir, path), joinpath(tmp, path))
+      end
   end
   atexit(() -> isdir(tmp) && rm(tmp, recursive=true))
   return tmp


### PR DESCRIPTION
Currently, Vimes only copies certain files and folders from the source directory to the temporary directory. The included files and folders are:
- `Project.toml`
- `Manifest.toml`
- `src`
- `test`
- `deps`

However, I have several Julia packages in which the test suite relies on files located in folders not listed above.

This pull request copies all files and folders (except the `.git` folder) from the source directory to the temporary directory.
