### PR TITLE
Modify `go(...)` so that it returns `(runs, pass)` on completion

### DIFF
--- a/src/run.jl
+++ b/src/run.jl
@@ -65,7 +65,7 @@ function test(dir, tmp, idx; dead = false)
   return !pass
 end
 
-function go(dir, ps = defaults; procs = 1, dead = false, tests = typemax(Int))::Tuple{Int, Int}
+function go(dir, ps = defaults; procs = 1, dead = false, tests = typemax(Int))::Int
   runs, pass = 0, 0
   function run(r, i)
     runs += 1
@@ -83,5 +83,5 @@ function go(dir, ps = defaults; procs = 1, dead = false, tests = typemax(Int))::
       end
     end
   end
-  return (runs, pass)
+  return pass
 end

--- a/src/run.jl
+++ b/src/run.jl
@@ -65,7 +65,7 @@ function test(dir, tmp, idx; dead = false)
   return !pass
 end
 
-function go(dir, ps = defaults; procs = 1, dead = false, tests = typemax(Int))
+function go(dir, ps = defaults; procs = 1, dead = false, tests = typemax(Int))::Tuple{Int, Int}
   runs, pass = 0, 0
   function run(r, i)
     runs += 1
@@ -83,4 +83,5 @@ function go(dir, ps = defaults; procs = 1, dead = false, tests = typemax(Int))
       end
     end
   end
+  return (runs, pass)
 end


### PR DESCRIPTION
This pull request modifies `Vimes.go(...)` so that it returns `(runs, pass)` on completion.

This will allow users to run Vimes automatically and integrate Vimes into a larger test framework. For example, you could add Vimes  into your Travis test script, for `tests=20`, with the rule that if the precision is below 80%, then the Travis test script will exit with exit code 1 (thus failing the build).

cc: @MikeInnes 