### PR TITLE
Fix syntax error (bad quotation marks)

### DIFF
--- a/src/run.jl
+++ b/src/run.jl
@@ -15,7 +15,7 @@ function initialise(dir)
   tmp = joinpath(tempdir(), "vimes-$(rand(UInt64))")
   mkdir(tmp)
   for path in readdir(dir)
-      if !startswith(path, “.”)
+      if !startswith(path, ".")
           cp(joinpath(dir, path), joinpath(tmp, path))
       end
   end


### PR DESCRIPTION
I must have inserted some "curly" quotation marks when editing from mobile. They cause a syntax error.

This pull request changes them to normal quotation marks.